### PR TITLE
Fix pointer math for revert reason bubbling

### DIFF
--- a/test/MultiSigAdmin.test.ts
+++ b/test/MultiSigAdmin.test.ts
@@ -1288,7 +1288,7 @@ contract("MultiSigAdmin", (accounts) => {
       const [proposalId] = await proposeAndGetId(
         target1.address,
         revertWithError,
-        [["string"], ["something went wrong spectacularly"]],
+        [["string"], ["something went wrong"]],
         approver1
       );
       await msa.approve(proposalId, { from: approver1 });
@@ -1296,7 +1296,7 @@ contract("MultiSigAdmin", (accounts) => {
       // Check that it reverts with the reason of the failure
       await expectRevert(
         msa.execute(proposalId, { from: approver1 }),
-        "call failed: something went wrong spectacularly"
+        "call failed: something went wrong"
       );
 
       // Check that the proposal state is still open and executable, and not


### PR DESCRIPTION
Return data will be at least 100 bytes if it contains the reason string: Error(string) selector[4] + string offset[32] + string length[32] + string data[32] = 100

If the reason string exists, to extract the string, the pointer must be moved 68 bytes forward: bytes length[32] + Error(string) selector[4] + string offset[32] = 68